### PR TITLE
:art: docker部署优化.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,13 @@ FROM  alpine
 # 安装必要的工具包
 RUN  apk --update --no-cache add tzdata ca-certificates \
     && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
-RUN mkdir /etc/v2node/
-COPY --from=builder /app/v2node /usr/local/bin
+RUN mkdir -p /usr/local/v2node /etc/v2node
+COPY --from=builder /app/v2node /usr/local/v2node/v2node
+COPY script/v2node.sh /usr/bin/v2node
+COPY script/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/v2node/v2node /usr/bin/v2node /usr/local/bin/docker-entrypoint.sh
 
-ENTRYPOINT [ "v2node", "server", "--config", "/etc/v2node/config.json"]
+ENV V2NODE_CONFIG=/etc/v2node/config.json
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["server"]

--- a/README.md
+++ b/README.md
@@ -6,10 +6,53 @@ A v2board backend base on moddified xray-core.
 
 ## 软件安装
 
-### 一键安装
+### 一键安装（Linux）
 
-```
+```bash
 wget -N https://raw.githubusercontent.com/wyx2685/v2node/master/script/install.sh && bash install.sh
+```
+
+### Docker
+
+**方式一：通过环境变量自动初始化（推荐）**
+
+容器首次启动时若 `/etc/v2node/config.json` 不存在，将自动根据环境变量生成配置，等价于 `v2node generate`。
+
+```bash
+docker run -d --name v2node \
+  -e V2NODE_API_HOST="https://your-panel.example.com" \
+  -e V2NODE_NODE_ID=1 \
+  -e V2NODE_API_KEY="your_api_key_here" \
+  -v v2node-config:/etc/v2node \
+  --network=host \
+  ghcr.io/wyx2685/v2node
+```
+
+支持的环境变量：
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `V2NODE_API_HOST` | 面板 API 地址 | — |
+| `V2NODE_NODE_ID` | 节点 ID，支持 `1` 或 `"1,2,3"`（同一面板多节点，逗号分隔） | — |
+| `V2NODE_API_KEY` | 节点通讯密钥 | — |
+| `V2NODE_LOG_LEVEL` | 日志级别 | `warning` |
+| `V2NODE_LOG_ACCESS` | 访问日志 | `none` |
+| `V2NODE_TIMEOUT` | API 超时（秒） | `15` |
+| `V2NODE_SKIP_GENERATE` | 设为任意值则跳过自动生成 | — |
+
+**方式二：挂载已有配置文件**
+
+```bash
+docker run -d --name v2node \
+  -v /etc/v2node/config.json:/etc/v2node/config.json \
+  --network=host \
+  ghcr.io/wyx2685/v2node
+```
+
+**构建本地镜像**
+
+```bash
+docker build -t v2node:local .
 ```
 
 ## 构建

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  v2node:
+    build: .
+    container_name: ghcr.io/wyx2685/v2node
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      V2NODE_API_HOST: "https://your-panel.example.com"
+      V2NODE_NODE_ID: "1"
+      V2NODE_API_KEY: "your_api_key_here"
+    volumes:
+      - /etc/v2node:/etc/v2node

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+
+set -e
+
+BIN="/usr/local/v2node/v2node"
+CONF_PATH="${V2NODE_CONFIG:-/etc/v2node/config.json}"
+
+# Ensure config directory exists
+CONF_DIR="$(dirname "$CONF_PATH")"
+[ -d "$CONF_DIR" ] || mkdir -p "$CONF_DIR"
+
+# If config is missing and auto-generate is not disabled, try to generate from env vars
+if [ ! -f "$CONF_PATH" ] && [ -z "${V2NODE_SKIP_GENERATE:-}" ]; then
+  if [ -n "${V2NODE_API_HOST:-}" ] && [ -n "${V2NODE_NODE_ID:-}" ] && [ -n "${V2NODE_API_KEY:-}" ]; then
+    echo "[docker-entrypoint] Generating $CONF_PATH from environment variables" >&2
+
+    # Build Nodes array: V2NODE_NODE_ID supports comma-separated values (e.g. "1,2,3")
+    nodes_json=""
+    IFS=","
+    for id in ${V2NODE_NODE_ID}; do
+      id="$(echo "$id" | tr -d ' ')"
+      [ -z "$id" ] && continue
+      [ -n "$nodes_json" ] && nodes_json="${nodes_json},"
+      nodes_json="${nodes_json}
+    {
+      \"ApiHost\": \"${V2NODE_API_HOST}\",
+      \"NodeID\": ${id},
+      \"ApiKey\": \"${V2NODE_API_KEY}\",
+      \"Timeout\": ${V2NODE_TIMEOUT:-15}
+    }"
+    done
+    unset IFS
+
+    cat > "$CONF_PATH" <<EOF
+{
+  "Log": {
+    "Level": "${V2NODE_LOG_LEVEL:-warning}",
+    "Output": "${V2NODE_LOG_OUTPUT:-}",
+    "Access": "${V2NODE_LOG_ACCESS:-none}"
+  },
+  "Nodes": [${nodes_json}
+  ]
+}
+EOF
+  else
+    echo "[docker-entrypoint] Config $CONF_PATH does not exist and V2NODE_API_HOST/V2NODE_NODE_ID/V2NODE_API_KEY are not all set" >&2
+    echo "[docker-entrypoint] Either mount an existing config file or set these env vars to enable auto-generation." >&2
+    exit 1
+  fi
+fi
+
+# Exec v2node with passed arguments (default CMD is [\"server\"])
+exec "$BIN" "$@"


### PR DESCRIPTION
增加docker部署优化
### Docker

**方式一：通过环境变量自动初始化（推荐）**

容器首次启动时若 `/etc/v2node/config.json` 不存在，将自动根据环境变量生成配置，等价于 `v2node generate`。

```bash
docker run -d --name v2node \
  -e V2NODE_API_HOST="https://your-panel.example.com" \
  -e V2NODE_NODE_ID=1 \
  -e V2NODE_API_KEY="your_api_key_here" \
  -v v2node-config:/etc/v2node \
  --network=host \
  ghcr.io/wyx2685/v2node
```

支持的环境变量：

| 变量 | 说明 | 默认值 |
|------|------|--------|
| `V2NODE_API_HOST` | 面板 API 地址 | — |
| `V2NODE_NODE_ID` | 节点 ID，支持 `1` 或 `"1,2,3"`（同一面板多节点，逗号分隔） | — |
| `V2NODE_API_KEY` | 节点通讯密钥 | — |
| `V2NODE_LOG_LEVEL` | 日志级别 | `warning` |
| `V2NODE_LOG_ACCESS` | 访问日志 | `none` |
| `V2NODE_TIMEOUT` | API 超时（秒） | `15` |
| `V2NODE_SKIP_GENERATE` | 设为任意值则跳过自动生成 | — |

**方式二：挂载已有配置文件**

```bash
docker run -d --name v2node \
  -v /etc/v2node/config.json:/etc/v2node/config.json \
  --network=host \
  ghcr.io/wyx2685/v2node
```

**构建本地镜像**

```bash
docker build -t v2node:local .
```
