### PR TITLE
修复内核重载时 ihm 为 nil 导致 GetUserManager 空指针崩溃

### DIFF
--- a/core/user.go
+++ b/core/user.go
@@ -25,6 +25,9 @@ import (
 )
 
 func (v *V2Core) GetUserManager(tag string) (proxy.UserManager, error) {
+	if v == nil || v.ihm == nil {
+		return nil, fmt.Errorf("inbound handler manager is not ready")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	handler, err := v.ihm.GetHandler(ctx, tag)


### PR DESCRIPTION
v2node v0.4.1 在节点和面板通信偶尔卡顿、内核重载的时候，会偶发 panic 然后被 systemd 反复拉起。崩溃堆栈定位在 core/user.go:30 的 v.ihm.GetHandler(ctx, tag)，信号是 addr=0x28 的空指针，应该是这一刻 v.ihm 还是 nil。

推测是内核重载的瞬间 ihm 还没赋值好，而 nodeInfoMonitor 这个定时任务正好同时调了 AddUsers → GetUserManager，对 nil 的 ihm 取值就崩了，是个并发时机问题。日志里那些 “no such inbound tag” 是走了正常的返回 error 分支、被处理掉的，真正让进程挂掉的是 ihm 为 nil 这一下。

 在 GetUserManager 开头加了个判空：v 或 v.ihm 为 nil 时直接返回 error，让上层 AddUsers 走它已有的错误处理分支优雅返回，而不是 panic 整个进程。

参考崩溃堆栈：


panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28]
core.(*V2Core).GetUserManager  core/user.go:30
core.(*V2Core).AddUsers        core/user.go:137
node.(*Controller).nodeInfoMonitor  node/task.go:127